### PR TITLE
Add app name replacements

### DIFF
--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -3,7 +3,7 @@ import { cfg } from "./config";
 import { CLIENT_ID, LASTFM_KEY } from "./constants";
 
 const { React } = common;
-const { Divider, Text, TextInput, SwitchItem } = components;
+const { Divider, Text, TextInput, SwitchItem, FormText } = components;
 
 export function Settings(): React.ReactElement {
   return (
@@ -14,7 +14,12 @@ export function Settings(): React.ReactElement {
 
       <Text.Eyebrow style={{ marginBottom: "5px" }}>App Name</Text.Eyebrow>
       <TextInput {...util.useSetting(cfg, "appName")} placeholder="Music" />
-      <Divider style={{ marginTop: "10px", marginBottom: "10px" }} />
+      <FormText.DESCRIPTION style={{ marginTop: "8px" }}>
+        "{"{title}"}" is replaced with current track name<br/>
+        "{"{artist}"}" is replaced with current track artist<br/>
+        "{"{album}"}" is replaced with current track album name
+      </FormText.DESCRIPTION>
+      <Divider style={{ marginTop: "10px", marginBottom: "20px" }} />
 
       <SwitchItem
         {...util.useSetting(cfg, "shareUsername")}

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,17 @@ async function getActivity(): Promise<Activity | undefined> {
   if (assets.large_image) assets.large_image = await getAppAsset(assets.large_image);
   if (assets.small_image) assets.small_image = await getAppAsset(assets.small_image);
 
+  let appName = cfg.get("appName") || "Music";
+  appName = appName.replace(/{[a-zA-Z0-9]+}/g, function(match) {
+    return match === "{title}" ? track.name :
+      match === "{artist}" ? track.artist["#text"] :
+      match === "{album}" ? track.album["#text"] :
+      match;
+  });
+
   /* eslint-disable @typescript-eslint/naming-convention */
   return {
-    name: cfg.get("appName") || "Music",
+    name: appName,
     application_id: getClientID(),
 
     type: ActivityType.Listening,


### PR DESCRIPTION
Allows using `{title}`, `{artist}` and `{album}` to insert the current track name, artist and album name into the app name

### Examples:

#### {artist}
![image](https://github.com/RuiNtD/lastfm-rp-replugged/assets/30120687/5beb250e-9290-42d6-95b9-bfb86a926867)
![image](https://github.com/RuiNtD/lastfm-rp-replugged/assets/30120687/e468c7a4-276e-4a07-adef-9993a4174626)

#### {title} by {artist}
![image](https://github.com/RuiNtD/lastfm-rp-replugged/assets/30120687/73a160da-13ba-4097-aa97-60140b985d07)
![image](https://github.com/RuiNtD/lastfm-rp-replugged/assets/30120687/5d373d30-f925-4b2e-bc84-faa56904ec00)
